### PR TITLE
Netlify Error Fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,13 @@
 # Logs
 logs
 *.log
-.yarn
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,0 @@
-nodeLinker: node-modules
-
-yarnPath: .yarn/releases/yarn-3.2.2.cjs


### PR DESCRIPTION
 - Error: Cannot find module
 - '/opt/build/repo/.yarn/releases/yarn-3.2.2.cjs'
 - updated gitignore to make yarn-3.2.2.cjs available